### PR TITLE
fix(suedtirolwein): fix api-crawler pagination and transformer base language initialization

### DIFF
--- a/collectors/api-crawler/infrastructure/crawler-config/suedtirolwein-companies.silky.yaml
+++ b/collectors/api-crawler/infrastructure/crawler-config/suedtirolwein-companies.silky.yaml
@@ -13,7 +13,12 @@ steps:
         request:
           url: "https://www.suedtirolwein.com/api/collections/winzers/entries?filter[site]={{ .language }}"
           method: GET
+          pagination:
+            nextPageUrlSelector: body:.links.next
+            stopOn:
+              - type: responseBody
+                expression: ".links.next == null"
 
-        resultTransformer: "."
+        resultTransformer: ".data"
 
-        mergeOn: .[$ctx.language] = $res
+        mergeOn: .[$ctx.language].data = $res

--- a/transformers/suedtirolwein/src/main.go
+++ b/transformers/suedtirolwein/src/main.go
@@ -271,7 +271,6 @@ func Transform(ctx context.Context, r *rdb.Raw[dto.RawData]) error {
 		{"de", companiesFromLang(r.Rawdata.De)},
 		{"it", companiesFromLang(r.Rawdata.It)},
 		{"en", companiesFromLang(r.Rawdata.En)},
-		{"ru", companiesFromLang(r.Rawdata.Ru)},
 	}
 
 	pois := map[string]odhContentModel.ODHActivityPoi{}
@@ -354,6 +353,7 @@ func Transform(ctx context.Context, r *rdb.Raw[dto.RawData]) error {
 					poi.PublishedOn = cachedEntry.Entity.PublishedOn
 				}
 				poi.PublishedOn = addChannels(poi.PublishedOn, getPublishedOnChannels())
+				mergeLang(&poi, company, batch.lang)
 
 				pois[id] = poi
 			}


### PR DESCRIPTION
Changes:

Crawler: Added pagination logic to suedtirolwein-companies.silky.yaml using body:.links.next. The crawler now fetches all pages instead of only the first 50 companies, resolving the issue where DE master records were missing.

Transformer: Removed the unused ru translation batch. Also fixed a bug in mapToPoi logic where the newly created POI was not receiving the translation details (mergeLang) for the first parsed language, causing valid companies to be dropped by ODH validations.