### PR TITLE
fix(suedtirolwein): fix api-crawler pagination truncation issue

### DIFF
--- a/collectors/api-crawler/infrastructure/crawler-config/suedtirolwein-companies.silky.yaml
+++ b/collectors/api-crawler/infrastructure/crawler-config/suedtirolwein-companies.silky.yaml
@@ -19,6 +19,6 @@ steps:
               - type: responseBody
                 expression: ".links.next == null"
 
-        resultTransformer: ".data"
+        resultTransformer: "."
 
-        mergeOn: .[$ctx.language].data = $res
+        mergeOn: .[$ctx.language].data = ($res | map(.data) | flatten)


### PR DESCRIPTION
The previous crawler configuration used resultTransformer: ".data", which inadvertently stripped the .links object from the paginated responses. This caused the stopOn condition (.links.next == null) to evaluate to true immediately on the first page, resulting in the crawler only fetching 50 items. This truncation led to the transformer deactivating hundreds of active companies because they were missing from the sync.

Changes:
Changed resultTransformer to '.' to preserve the full response payload (including .links) so silky can successfully paginate through all 6 pages.
Updated mergeOn to use ($res | map(.data) | flatten) to correctly aggregate and flatten the array of all paginated data blocks into a single list of companies for the transformer.